### PR TITLE
feat: add `prefixDefaultLocale` option to `i18nPropsAndParams`

### DIFF
--- a/.changeset/better-dryers-rule.md
+++ b/.changeset/better-dryers-rule.md
@@ -1,0 +1,5 @@
+---
+"astro-loader-i18n": patch
+---
+
+Add `prefixDefaultLocale` option to `i18nPropsAndParams` (thank you @duy-the-developer)

--- a/libs/astro-loader-i18n/src/props-and-params/i18n-props-and-params.ts
+++ b/libs/astro-loader-i18n/src/props-and-params/i18n-props-and-params.ts
@@ -13,12 +13,14 @@ type Config = {
   localeParamName?: string;
   slugParamName?: string;
   titleDataKey?: string;
+  prefixDefaultLocale?: boolean;
 };
 
 const defaultConfig = {
   localeParamName: "locale",
   slugParamName: "slug",
   titleDataKey: "title",
+  prefixDefaultLocale: false,
 } as const;
 
 function getSegmentTranslations(
@@ -27,7 +29,7 @@ function getSegmentTranslations(
 ) {
   if (!c.segmentTranslations[data.locale]) throw new Error(`No slugs found for locale ${data.locale}`);
 
-  const currentLocale = data.locale === c.defaultLocale ? undefined : data.locale;
+  const currentLocale = !c.prefixDefaultLocale && data.locale === c.defaultLocale ? undefined : data.locale;
   const segmentValues = { [c.localeParamName]: currentLocale, ...c.segmentTranslations[data.locale] };
 
   const slugValue = c.titleDataKey ? data[c.titleDataKey] : undefined;

--- a/libs/astro-loader-i18n/test/props-and-params/__snapshots__/i18n-props-and-params.spec.ts.snap
+++ b/libs/astro-loader-i18n/test/props-and-params/__snapshots__/i18n-props-and-params.spec.ts.snap
@@ -1,11 +1,11 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`i18nPropsAndParams > should generate full paths if prefixDefaultLocale is true 1`] = `
+exports[`i18nPropsAndParams > should generate paths for a valid collection 1`] = `
 [
   {
     "params": {
       "blog": "logbuch",
-      "locale": "de-CH",
+      "locale": undefined,
       "slug": "test/veruckte-umlaute",
     },
     "props": {
@@ -16,9 +16,9 @@ exports[`i18nPropsAndParams > should generate full paths if prefixDefaultLocale 
         "title": "Verückte Umlaute!",
         "translationId": "magic.mdx",
       },
-      "translatedPath": "/de-CH/logbuch/posts/test/veruckte-umlaute",
+      "translatedPath": "/logbuch/posts/test/veruckte-umlaute",
       "translations": {
-        "de-CH": "/de-CH/logbuch/posts/test/veruckte-umlaute",
+        "de-CH": "/logbuch/posts/test/veruckte-umlaute",
         "zh-CN": "/zh-CN/blog/posts/test/shen2-qi2-de-biao1-ti2",
       },
     },
@@ -39,7 +39,7 @@ exports[`i18nPropsAndParams > should generate full paths if prefixDefaultLocale 
       },
       "translatedPath": "/zh-CN/blog/posts/test/shen2-qi2-de-biao1-ti2",
       "translations": {
-        "de-CH": "/de-CH/logbuch/posts/test/veruckte-umlaute",
+        "de-CH": "/logbuch/posts/test/veruckte-umlaute",
         "zh-CN": "/zh-CN/blog/posts/test/shen2-qi2-de-biao1-ti2",
       },
     },
@@ -87,53 +87,6 @@ exports[`i18nPropsAndParams > should generate full paths if prefixDefaultLocale 
       "translatedPath": "/zh-CN/blog/posts/test/shen2-qi2-de-biao1-ti2",
       "translations": {
         "de-CH": "/de-CH/logbuch/posts/test/veruckte-umlaute",
-        "zh-CN": "/zh-CN/blog/posts/test/shen2-qi2-de-biao1-ti2",
-      },
-    },
-  },
-]
-`;
-
-exports[`i18nPropsAndParams > should generate paths for a valid collection 1`] = `
-[
-  {
-    "params": {
-      "blog": "logbuch",
-      "locale": undefined,
-      "slug": "test/veruckte-umlaute",
-    },
-    "props": {
-      "data": {
-        "basePath": "/",
-        "contentPath": "test",
-        "locale": "de-CH",
-        "title": "Verückte Umlaute!",
-        "translationId": "magic.mdx",
-      },
-      "translatedPath": "/logbuch/posts/test/veruckte-umlaute",
-      "translations": {
-        "de-CH": "/logbuch/posts/test/veruckte-umlaute",
-        "zh-CN": "/zh-CN/blog/posts/test/shen2-qi2-de-biao1-ti2",
-      },
-    },
-  },
-  {
-    "params": {
-      "blog": "blog",
-      "locale": "zh-CN",
-      "slug": "test/shen2-qi2-de-biao1-ti2",
-    },
-    "props": {
-      "data": {
-        "basePath": "/",
-        "contentPath": "test",
-        "locale": "zh-CN",
-        "title": "神奇的标题",
-        "translationId": "magic.mdx",
-      },
-      "translatedPath": "/zh-CN/blog/posts/test/shen2-qi2-de-biao1-ti2",
-      "translations": {
-        "de-CH": "/logbuch/posts/test/veruckte-umlaute",
         "zh-CN": "/zh-CN/blog/posts/test/shen2-qi2-de-biao1-ti2",
       },
     },

--- a/libs/astro-loader-i18n/test/props-and-params/__snapshots__/i18n-props-and-params.spec.ts.snap
+++ b/libs/astro-loader-i18n/test/props-and-params/__snapshots__/i18n-props-and-params.spec.ts.snap
@@ -1,5 +1,99 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`i18nPropsAndParams > should generate full paths if prefixDefaultLocale is true 1`] = `
+[
+  {
+    "params": {
+      "blog": "logbuch",
+      "locale": "de-CH",
+      "slug": "test/veruckte-umlaute",
+    },
+    "props": {
+      "data": {
+        "basePath": "/",
+        "contentPath": "test",
+        "locale": "de-CH",
+        "title": "Verückte Umlaute!",
+        "translationId": "magic.mdx",
+      },
+      "translatedPath": "/de-CH/logbuch/posts/test/veruckte-umlaute",
+      "translations": {
+        "de-CH": "/de-CH/logbuch/posts/test/veruckte-umlaute",
+        "zh-CN": "/zh-CN/blog/posts/test/shen2-qi2-de-biao1-ti2",
+      },
+    },
+  },
+  {
+    "params": {
+      "blog": "blog",
+      "locale": "zh-CN",
+      "slug": "test/shen2-qi2-de-biao1-ti2",
+    },
+    "props": {
+      "data": {
+        "basePath": "/",
+        "contentPath": "test",
+        "locale": "zh-CN",
+        "title": "神奇的标题",
+        "translationId": "magic.mdx",
+      },
+      "translatedPath": "/zh-CN/blog/posts/test/shen2-qi2-de-biao1-ti2",
+      "translations": {
+        "de-CH": "/de-CH/logbuch/posts/test/veruckte-umlaute",
+        "zh-CN": "/zh-CN/blog/posts/test/shen2-qi2-de-biao1-ti2",
+      },
+    },
+  },
+]
+`;
+
+exports[`i18nPropsAndParams > should generate full paths if prefixDefaultLocale is true 2`] = `
+[
+  {
+    "params": {
+      "blog": "logbuch",
+      "locale": undefined,
+      "slug": "test/veruckte-umlaute",
+    },
+    "props": {
+      "data": {
+        "basePath": "/",
+        "contentPath": "test",
+        "locale": "de-CH",
+        "title": "Verückte Umlaute!",
+        "translationId": "magic.mdx",
+      },
+      "translatedPath": "/de-CH/logbuch/posts/test/veruckte-umlaute",
+      "translations": {
+        "de-CH": "/de-CH/logbuch/posts/test/veruckte-umlaute",
+        "zh-CN": "/zh-CN/blog/posts/test/shen2-qi2-de-biao1-ti2",
+      },
+    },
+  },
+  {
+    "params": {
+      "blog": "blog",
+      "locale": "zh-CN",
+      "slug": "test/shen2-qi2-de-biao1-ti2",
+    },
+    "props": {
+      "data": {
+        "basePath": "/",
+        "contentPath": "test",
+        "locale": "zh-CN",
+        "title": "神奇的标题",
+        "translationId": "magic.mdx",
+      },
+      "translatedPath": "/zh-CN/blog/posts/test/shen2-qi2-de-biao1-ti2",
+      "translations": {
+        "de-CH": "/de-CH/logbuch/posts/test/veruckte-umlaute",
+        "zh-CN": "/zh-CN/blog/posts/test/shen2-qi2-de-biao1-ti2",
+      },
+    },
+  },
+]
+`;
+
 exports[`i18nPropsAndParams > should generate paths for a valid collection 1`] = `
 [
   {

--- a/libs/astro-loader-i18n/test/props-and-params/__snapshots__/i18n-props-and-params.spec.ts.snap
+++ b/libs/astro-loader-i18n/test/props-and-params/__snapshots__/i18n-props-and-params.spec.ts.snap
@@ -47,7 +47,7 @@ exports[`i18nPropsAndParams > should generate paths for a valid collection 1`] =
 ]
 `;
 
-exports[`i18nPropsAndParams > should generate full paths if prefixDefaultLocale is true 2`] = `
+exports[`i18nPropsAndParams > should generate full paths if prefixDefaultLocale is true 1`] = `
 [
   {
     "params": {

--- a/libs/astro-loader-i18n/test/props-and-params/__snapshots__/i18n-props-and-params.spec.ts.snap
+++ b/libs/astro-loader-i18n/test/props-and-params/__snapshots__/i18n-props-and-params.spec.ts.snap
@@ -1,5 +1,52 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`i18nPropsAndParams > should generate full paths if prefixDefaultLocale is true 1`] = `
+[
+  {
+    "params": {
+      "blog": "logbuch",
+      "locale": "de-CH",
+      "slug": "test/veruckte-umlaute",
+    },
+    "props": {
+      "data": {
+        "basePath": "/",
+        "contentPath": "test",
+        "locale": "de-CH",
+        "title": "Verückte Umlaute!",
+        "translationId": "magic.mdx",
+      },
+      "translatedPath": "/de-CH/logbuch/posts/test/veruckte-umlaute",
+      "translations": {
+        "de-CH": "/de-CH/logbuch/posts/test/veruckte-umlaute",
+        "zh-CN": "/zh-CN/blog/posts/test/shen2-qi2-de-biao1-ti2",
+      },
+    },
+  },
+  {
+    "params": {
+      "blog": "blog",
+      "locale": "zh-CN",
+      "slug": "test/shen2-qi2-de-biao1-ti2",
+    },
+    "props": {
+      "data": {
+        "basePath": "/",
+        "contentPath": "test",
+        "locale": "zh-CN",
+        "title": "神奇的标题",
+        "translationId": "magic.mdx",
+      },
+      "translatedPath": "/zh-CN/blog/posts/test/shen2-qi2-de-biao1-ti2",
+      "translations": {
+        "de-CH": "/de-CH/logbuch/posts/test/veruckte-umlaute",
+        "zh-CN": "/zh-CN/blog/posts/test/shen2-qi2-de-biao1-ti2",
+      },
+    },
+  },
+]
+`;
+
 exports[`i18nPropsAndParams > should generate paths for a valid collection 1`] = `
 [
   {
@@ -40,53 +87,6 @@ exports[`i18nPropsAndParams > should generate paths for a valid collection 1`] =
       "translatedPath": "/zh-CN/blog/posts/test/shen2-qi2-de-biao1-ti2",
       "translations": {
         "de-CH": "/logbuch/posts/test/veruckte-umlaute",
-        "zh-CN": "/zh-CN/blog/posts/test/shen2-qi2-de-biao1-ti2",
-      },
-    },
-  },
-]
-`;
-
-exports[`i18nPropsAndParams > should generate full paths if prefixDefaultLocale is true 1`] = `
-[
-  {
-    "params": {
-      "blog": "logbuch",
-      "locale": undefined,
-      "slug": "test/veruckte-umlaute",
-    },
-    "props": {
-      "data": {
-        "basePath": "/",
-        "contentPath": "test",
-        "locale": "de-CH",
-        "title": "Verückte Umlaute!",
-        "translationId": "magic.mdx",
-      },
-      "translatedPath": "/de-CH/logbuch/posts/test/veruckte-umlaute",
-      "translations": {
-        "de-CH": "/de-CH/logbuch/posts/test/veruckte-umlaute",
-        "zh-CN": "/zh-CN/blog/posts/test/shen2-qi2-de-biao1-ti2",
-      },
-    },
-  },
-  {
-    "params": {
-      "blog": "blog",
-      "locale": "zh-CN",
-      "slug": "test/shen2-qi2-de-biao1-ti2",
-    },
-    "props": {
-      "data": {
-        "basePath": "/",
-        "contentPath": "test",
-        "locale": "zh-CN",
-        "title": "神奇的标题",
-        "translationId": "magic.mdx",
-      },
-      "translatedPath": "/zh-CN/blog/posts/test/shen2-qi2-de-biao1-ti2",
-      "translations": {
-        "de-CH": "/de-CH/logbuch/posts/test/veruckte-umlaute",
         "zh-CN": "/zh-CN/blog/posts/test/shen2-qi2-de-biao1-ti2",
       },
     },

--- a/libs/astro-loader-i18n/test/props-and-params/i18n-props-and-params.spec.ts
+++ b/libs/astro-loader-i18n/test/props-and-params/i18n-props-and-params.spec.ts
@@ -18,6 +18,17 @@ describe("i18nPropsAndParams", () => {
     const result = i18nPropsAndParams(COLLECTION_FIXTURE, { routePattern, segmentTranslations, defaultLocale: "de-CH" });
     expect(result).toMatchSnapshot();
   });
+  it("should generate full paths if prefixDefaultLocale is true", () => {
+    const routePattern = "[...locale]/[blog]/posts/[...slug]";
+    const segmentTranslations: SegmentTranslations = { "de-CH": { blog: "logbuch" }, "zh-CN": { blog: "blog" } };
+    const result = i18nPropsAndParams(COLLECTION_FIXTURE, {
+      routePattern,
+      segmentTranslations,
+      defaultLocale: "de-CH",
+      prefixDefaultLocale: true,
+    });
+    expect(result).toMatchSnapshot();
+  });
   it("should should throw an error if the slug needs to be a spread param, but isn't", () => {
     const routePattern = "[...locale]/[blog]/posts/[slug]";
     const segmentTranslations: SegmentTranslations = { "de-CH": { blog: "logbuch" }, "zh-CN": { blog: "blog" } };


### PR DESCRIPTION
Hey Robin! Love your work, found it to be the only proper way to fetch and consume i18n contents in an Astro project. I wanted to make a small contribution. 

## Reason
Allow users to use `prefixDefaultLocale` as a routing strategy.
## Changes
- Add `prefixDefaultLocale` to `i18n-props-and-params` `Config`.
- Add test + snapshot

Sorry I didn't know how `changesets/cli` works and may not have updated the CHANGELOG properly.